### PR TITLE
Make clang-tidy more strict

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,56 @@
+Checks: >
+  modernize-*,
+  performance-*,
+  portability-*,
+  readability-*,
+  -google-readability-braces-around-statements,
+  -google-readability-namespace-comments,
+  -google-runtime-references,
+  -misc-non-private-member-variables-in-classes,
+  -misc-const-correctness,
+  -misc-include-cleaner,
+  -modernize-return-braced-init-list,
+  -modernize-use-trailing-return-type,
+  -modernize-concat-nested-namespaces,
+  -modernize-use-nodiscard,
+  -modernize-avoid-c-arrays,
+  -performance-move-const-arg,
+  -performance-avoid-endl,
+  -readability-braces-around-statements,
+  -readability-identifier-length,
+  -readability-magic-numbers,
+  -readability-named-parameter,
+  -readability-redundant-declaration,
+  -readability-function-cognitive-complexity,
+  -bugprone-narrowing-conversions,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-unchecked-optional-access,
+  -clang-analyzer-security.insecureAPI.rand,
+
+WarningsAsErrors: "*"
+
+CheckOptions:
+  - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }
+  - { key: readability-identifier-naming.ClassCase,              value: CamelCase  }
+  - { key: readability-identifier-naming.StructCase,             value: CamelCase  }
+  - { key: readability-identifier-naming.TemplateParameterCase,  value: CamelCase  }
+  - { key: readability-identifier-naming.FunctionCase,           value: aNy_CasE  }
+  - { key: readability-identifier-naming.VariableCase,           value: lower_case }
+  - { key: readability-identifier-naming.ClassMemberCase,        value: lower_case }
+  - { key: readability-identifier-naming.ClassMemberSuffix,      value: _          }
+  - { key: readability-identifier-naming.PrivateMemberSuffix,    value: _          }
+  - { key: readability-identifier-naming.ProtectedMemberSuffix,  value: _          }
+  - { key: readability-identifier-naming.EnumConstantCase,         value: CamelCase }
+  - { key: readability-identifier-naming.EnumConstantPrefix,       value: k         }
+  - { key: readability-identifier-naming.ConstexprVariableCase,    value: CamelCase }
+  - { key: readability-identifier-naming.ConstexprVariablePrefix,  value: k         }
+  - { key: readability-identifier-naming.GlobalConstantCase,       value: CamelCase }
+  - { key: readability-identifier-naming.GlobalConstantPrefix,     value: k         }
+  - { key: readability-identifier-naming.MemberConstantCase,       value: CamelCase }
+  - { key: readability-identifier-naming.MemberConstantPrefix,     value: k         }
+  - { key: readability-identifier-naming.StaticConstantCase,       value: CamelCase }
+  - { key: readability-identifier-naming.StaticConstantPrefix,     value: k         }
+  - { key: readability-implicit-bool-conversion.AllowIntegerConditions,  value: 1   }
+  - { key: readability-implicit-bool-conversion.AllowPointerConditions,  value: 1   }
+  - { key: readability-function-cognitive-complexity.IgnoreMacros,  value: 1   }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -96,14 +96,14 @@ TEST(timer, is_elapsed_time_omp_avg_returns_nearly_correct_time) {
 TEST(accuracy, max_accuracy_test) {
   double a[10] = {9.0, 2.0, 1.0, 4.0, 7.0, 10.5, -12.0, 11.0, 0.0, -2.5};
   double b[10] = {9.0, 2.0, 1.0, 4.0, 7.0, 10.5, -12.0, 11.0, 0.0, -2.5};
-  double acc = accuracy<double>(a, b, 10);
+  auto acc = accuracy<double>(a, b, 10);
   EXPECT_NEAR(acc, 0.0, 1e-5);
 }
 
 TEST(accuracy, bad_accuracy_test_S) {
   double a[2] = {0.5, 2.7};
   double b[2] = {1.7, 100.8};
-  double acc = accuracy<double>(a, b, 2);
+  auto acc = accuracy<double>(a, b, 2);
   EXPECT_NEAR(acc, 99.3, 1e-5);
 }
 
@@ -112,32 +112,32 @@ TEST(accuracy, bad_accuracy_test_M) {
                   10.48, -12.0, 10.494, 0.0, -2.240001};
   double b[10] = {0.0,  -6.0, 12.0, 44.006, -7.0,
                   11.0, 12.0, 0.0,  0.0,    -6.990001};
-  double acc = accuracy<double>(a, b, 10);
+  auto acc = accuracy<double>(a, b, 10);
   EXPECT_NEAR(acc, 122.27, 1e-5);
 }
 
 TEST(accuracy, bad_accuracy_test_L) {
-  size_t N = 5000;
+  size_t n = 5000;
   double a[5000];
   double b[5000];
-  for (size_t i = 0; i < N; i++) {
+  for (size_t i = 0; i < n; i++) {
     a[i] = (static_cast<double>(rand()) / RAND_MAX - 1.0) * 100;  // [-100;100]
   }
-  for (size_t i = 0; i < N; i++) {
+  for (size_t i = 0; i < n; i++) {
     b[i] = (static_cast<double>(rand()) / RAND_MAX - 1.0) * 100;  // [-100;100]
   }
   double actual_acc = 0.0;
-  for (size_t i = 0; i < N; i++) {
+  for (size_t i = 0; i < n; i++) {
     actual_acc += std::abs(a[i] - b[i]);
   }
-  double acc = accuracy<double>(a, b, 5000);
+  auto acc = accuracy<double>(a, b, 5000);
   EXPECT_NEAR(acc, actual_acc, 1e-5);
 }
 
 TEST(accuracy, bad_accuracy_norm_test_S) {
   double a[2] = {0.5, 2.7};
   double b[2] = {1.7, 100.8};
-  double acc = accuracy_norm<double>(a, b, 2);
+  auto acc = accuracy_norm<double>(a, b, 2);
   EXPECT_NEAR(acc, 98.10734, 1e-5);
 }
 
@@ -146,32 +146,32 @@ TEST(accuracy, bad_accuracy_norm_test_M) {
                   10.48, -12.0, 10.494, 0.0, -2.240001};
   double b[10] = {0.0,  -6.0, 12.0, 44.006, -7.0,
                   11.0, 12.0, 0.0,  0.0,    -6.990001};
-  double acc = accuracy_norm<double>(a, b, 10);
+  auto acc = accuracy_norm<double>(a, b, 10);
   EXPECT_NEAR(acc, 52.72274, 1e-5);
 }
 
 TEST(accuracy, bad_accuracy_norm_test_L) {
-  size_t N = 5000;
+  size_t n = 5000;
   double a[5000];
   double b[5000];
-  for (size_t i = 0; i < N; i++) {
+  for (size_t i = 0; i < n; i++) {
     a[i] = (static_cast<double>(rand()) / RAND_MAX - 1.0) * 100;  // [-100;100]
   }
-  for (size_t i = 0; i < N; i++) {
+  for (size_t i = 0; i < n; i++) {
     b[i] = (static_cast<double>(rand()) / RAND_MAX - 1.0) * 100;  // [-100;100]
   }
   double actual_acc = 0.0;
-  for (size_t i = 0; i < N; i++) {
+  for (size_t i = 0; i < n; i++) {
     actual_acc += (a[i] - b[i]) * (a[i] - b[i]);
   }
   actual_acc = std::sqrt(actual_acc);
-  double acc = accuracy_norm<double>(a, b, 5000);
+  auto acc = accuracy_norm<double>(a, b, 5000);
   EXPECT_NEAR(acc, actual_acc, 1e-5);
 }
 
 TEST(accuracy, accuracy_throws_when_bad_pointer) {
   double *a = nullptr;
-  double *b = new double[5];
+  auto *b = new double[5];
   EXPECT_ANY_THROW(accuracy<double>(a, b, 5));
   EXPECT_ANY_THROW(accuracy<double>(b, a, 5));
   delete[] b;
@@ -179,7 +179,7 @@ TEST(accuracy, accuracy_throws_when_bad_pointer) {
 
 TEST(accuracy, accuracy_norm_throws_when_bad_pointer) {
   double *a = nullptr;
-  double *b = new double[5];
+  auto *b = new double[5];
   EXPECT_ANY_THROW(accuracy_norm<double>(a, b, 5));
   EXPECT_ANY_THROW(accuracy_norm<double>(b, a, 5));
   delete[] b;


### PR DESCRIPTION
- Add check for code style
- Add more strict checks for Google Code Style. See https://github.com/googleapis/google-cloud-cpp/blob/main/.clang-tidy for the reference