### PR TITLE
[CI] Suppress code coverage errors due to mistaken negative hits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
     - name: Generate Coverage Data
-      run: gcovr -r . --xml -o coverage.xml
+      run: gcovr -r . --xml -o coverage.xml --gcov-ignore-parse-errors
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.0.1
       with:


### PR DESCRIPTION
Fix for the following error:
```
gcovr.formats.gcov.parser.NegativeHits: Got negative hit value in gcov line 'branch  2 taken -3' caused by a bug in gcov tool, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option --gcov-ignore-parse-errors with a value of negative_hits.warn, or negative_hits.warn_once_per_file.

Got negative hit value in gcov line 'branch  2 taken -3' caused by a bug in gcov tool, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option --gcov-ignore-parse-errors with a value of negative_hits.warn, or negative_hits.warn_once_per_file.
```