### PR TITLE
Enforce TBB threading for DNN library

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_subdirectory(googletest)
 
+set(DNNL_CPU_RUNTIME "TBB" CACHE STRING "oneDNN CPU threading runtime")
+
 add_subdirectory(oneDNN)
 
 # Unified TBB Configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ enable_testing()
 
 include_directories("include")
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+
 add_subdirectory(3rdparty)
 
 include(cmake/opencv_config.cmake)

--- a/cmake/FindTBB.cmake
+++ b/cmake/FindTBB.cmake
@@ -1,0 +1,27 @@
+# Lightweight FindTBB to reuse vendored TBB target from this project
+
+if(TARGET TBB::tbb)
+    set(_vendor_tbb_include "${CMAKE_SOURCE_DIR}/3rdparty/TBB/include")
+    if(EXISTS "${_vendor_tbb_include}/oneapi/tbb/version.h")
+        # TBB::tbb is an ALIAS; set properties on the real target 'tbb'
+        if(TARGET tbb)
+            set_target_properties(tbb PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${_vendor_tbb_include}")
+        endif()
+    endif()
+    set(TBB_FOUND TRUE)
+    # Provide minimal compatibility variables
+    set(TBB_IMPORTED_TARGETS TBB::tbb)
+    mark_as_advanced(TBB_FOUND)
+    unset(_vendor_tbb_include)
+    return()
+endif()
+
+# Create an imported INTERFACE target that links to our vendored TBB build target
+add_library(TBB::tbb INTERFACE IMPORTED)
+set_target_properties(TBB::tbb PROPERTIES
+    INTERFACE_LINK_LIBRARIES tbb
+    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/3rdparty/TBB/include"
+)
+set(TBB_FOUND TRUE)
+set(TBB_IMPORTED_TARGETS TBB::tbb)


### PR DESCRIPTION
- Use TBB threading by default.
   1. since vendored TBB is available in our project
   2. macOS does not have proper defaults sometimes that could make the build failed
- Use custom `cmake/FindTBB.cmake` to force using vendored TBB 
